### PR TITLE
Typo and Link Fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Please check our [testing guidelines](https://github.com/emyriounis/terraform-aw
 4. Make sure your changes are applied and existing functionality is not broken.
 5. Copy the updates you made to the `packages/ns-build/bin/ns-build.sh` file.
 
-### ns-img-rdr packeges
+### ns-img-rdr packages
 
 1. Make your changes
 2. Run `npm run prepare-lambda`
@@ -34,7 +34,7 @@ Please check our [testing guidelines](https://github.com/emyriounis/terraform-aw
 4. Re-deploy the module.
 5. Make sure your changes are applied and existing functionality is not broken.
 
-### ns-img-opt packeges
+### ns-img-opt packages
 
 1. Make your changes
 2. Run `npm run prepare-lambda`

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ terraform apply
 
 ## Examples
 
-- [Next.js v13](https://github.com/emyriounis/terraform-aws-nextjs-serverless/tree/main/examples/nextjs-v13) Complete example with SSR, API, static pages, image optimization & custom domain
+- [Next.js v14](https://github.com/emyriounis/terraform-aws-nextjs-serverless/tree/main/examples/nextjs-v14) Complete example with SSR, API, static pages, image optimization & custom domain
 
 ## Known Issues
 


### PR DESCRIPTION
Thanks for the great package.  This patch contains some minor clean-up for the documentation.

The link to the NextJS example directory pointed to the older version which no longer exists.

Some minor typo fixes.