### PR TITLE
Add error handling and some cleanup to ns-build.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ env.tfvars
 **/.DS_Store
 
 **/deployments/
-**/standalone/
+**/.ns-build/
 
 packages/**/*.zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ env.tfvars
 **/.DS_Store
 
 **/deployments/
+**/standalone/
 **/.ns-build/
 
 packages/**/*.zip

--- a/packages/ns-build/bin/ns-build.sh
+++ b/packages/ns-build/bin/ns-build.sh
@@ -67,16 +67,17 @@ npm run build || exit 1
 # Prepare deployment
 mkdir -p deployments || exit 1
 mkdir -p .ns-build || exit 1
+test -e standalone && rm -r standalone
 
 # Keep necessary files
 cp -a .next/static .next/standalone/.next || exit 1
-cp -a .next/standalone .ns-build/standalone || exit 1
-rm .ns-build/standalone/server.js || exit 1
-cp node_modules/ns-build/server.js .ns-build/standalone || exit 1
-cp next.config.js .ns-build/standalone || exit 1
+cp -a .next/standalone standalone || exit 1
+rm standalone/server.js || exit 1
+cp node_modules/ns-build/server.js standalone || exit 1
+cp next.config.js standalone || exit 1
 
 # Keeps necessary node modules
-cp -a .ns-build/standalone/node_modules .ns-build/nodejs || exit 1
+cp -a standalone/node_modules .ns-build/nodejs || exit 1
 cp -a node_modules/serverless .ns-build/nodejs/node_modules || exit 1
 cp -a node_modules/serverless-esbuild .ns-build/nodejs/node_modules || exit 1
 cp -a node_modules/esbuild .ns-build/nodejs/node_modules || exit 1
@@ -94,15 +95,15 @@ cp node_modules/ns-img-rdr/source.zip deployments/ns-img-rdr/ || exit 1
 cp node_modules/ns-img-opt/source.zip deployments/image-optimization/ || exit 1
 
 # Keep necessary files
-mkdir -p .ns-build/standalone/static/_next || exit 1
-cp -a .ns-build/standalone/.next/static .ns-build/standalone/static/_next || exit 1
+mkdir -p standalone/static/_next || exit 1
+cp -a standalone/.next/static standalone/static/_next || exit 1
 
 # Prepare source code
-test -d .ns-build/standalone/node_modules && rm -r .ns-build/standalone/node_modules
+test -d standalone/node_modules && rm -r standalone/node_modules
 
 # optinal: add node_modules
 if [ $copyAllPackages == true ]; then
-  cp -a .next/standalone/node_modules .ns-build/standalone/node_modules || exit 1
+  cp -a .next/standalone/node_modules standalone/node_modules || exit 1
 else
   mkdir node_modules
   for package in "${packages_to_copy[@]}"
@@ -113,5 +114,5 @@ fi
 
 # zip source code
 echo "Generating source.zip ..."
-( cd .ns-build/standalone && zip -r -q ../../deployments/source.zip * .[!.]* ) || exit 1
+( cd standalone && zip -r -q ../deployments/source.zip * .[!.]* ) || exit 1
 echo "source.zip generated !"

--- a/packages/ns-build/bin/ns-build.sh
+++ b/packages/ns-build/bin/ns-build.sh
@@ -5,11 +5,11 @@
 copyAllPackages=false
 for ARGUMENT in "$@"
 do
-  KEY=$(echo $ARGUMENT | cut -f1 -d=)
+  KEY="$(echo "$ARGUMENT" | cut -f1 -d=)"
 
-  if [[ $KEY == --copyAllPackages ]]; then
+  if [ "$KEY" == --copyAllPackages ]; then
     copyAllPackages=true
-  elif [[ $KEY == --packages-to-copy* ]]; then
+  elif [[ "$KEY" == --packages-to-copy* ]]; then
     KEY_LENGTH=${#KEY}
     VALUE="${ARGUMENT:$KEY_LENGTH+1}"
 
@@ -18,83 +18,100 @@ do
 done
 
 # Clean-up old builds
-rm -r .next
-rm -r standalone
-rm -r deployments
+test -d .next && rm -r .next
+test -d .ns-build && rm -r .ns-build
+test -d deployments && rm -r deployments
+
+# Prepare build directory
+mkdir -p .ns-build
+
+# Hook for cleaning up failed builds.
+function cleanup {
+  # Clean up interrupted code injection build.
+  if [ -d .ns-build/app-backup ] ; then
+    # Try to be safe in preserving the original app directory.
+    # However, note the lack of error checking.
+    test -d .ns-build/app-injected && rm -r .ns-build/app-injected
+    mv app .ns-build/app-injected
+    test -d app && rm -r app
+    mv .ns-build/app-backup app
+  fi
+
+  # Remove installed node modules
+  npm uninstall serverless serverless-esbuild esbuild serverless-http ns-img-opt ns-img-rdr
+
+  test -d .next && rm -r .next
+
+  # Keep the '.ns-build' and 'deployments' directories.
+  #   'deployments' contains the generated sources,
+  #   '.ns-build' contains the back-ups for bad previous cleanup attempts.
+  # Some parts of the .ns-build, though, do not need to stick around.
+  test -d .ns-build/nodejs && rm -r .ns-build/nodejs
+}
+trap cleanup EXIT INT HUP TERM
 
 # Install necessary packages
-npm i -D serverless@3.38.0 serverless-esbuild@1.49.0 esbuild@0.19.7 serverless-http@3.2.0 ns-img-opt@1.0.2 ns-img-rdr@1.0.2
+npm i -D \
+  serverless@3.38.0 serverless-esbuild@1.49.0 esbuild@0.19.7 serverless-http@3.2.0 ns-img-opt@1.0.2 ns-img-rdr@1.0.2 \
+  || exit 1
 
-# Inject code in build, and cleanup
-cp -a ./app ./app-backup
-find ./app -type f -name 'page.tsx' -exec sh -c 'printf "\nexport const runtime = '\''edge'\'';\n" >> "$0"' {} \;
-set -e
-npm run build
-set +e
-rm -r ./app
-mv ./app-backup ./app
+# Inject code in build
+if [ -d app ] ; then
+  # Note that cleanup from this happens if something fails.
+  cp -a app .ns-build/app-backup || exit 1
+  find app -type f -name 'page.tsx' -exec sh -c 'printf "\nexport const runtime = '\''edge'\'';\n" >> "$0"' {} \;
+fi
+npm run build || exit 1
 
-# Keep necessary files
-cp -a .next/static .next/standalone/.next
-cp -a .next/standalone standalone
-rm standalone/server.js
-cp node_modules/ns-build/server.js standalone
-cp next.config.js standalone
 
 # Prepare deployment
-mkdir deployments
-mkdir standalone
-mkdir nodejs
+mkdir -p deployments || exit 1
+mkdir -p .ns-build || exit 1
+
+# Keep necessary files
+cp -a .next/static .next/standalone/.next || exit 1
+cp -a .next/standalone .ns-build/standalone || exit 1
+rm .ns-build/standalone/server.js || exit 1
+cp node_modules/ns-build/server.js .ns-build/standalone || exit 1
+cp next.config.js .ns-build/standalone || exit 1
 
 # Keeps necessary node modules
-cp -a standalone/node_modules nodejs
-cp -a node_modules/serverless nodejs/node_modules
-cp -a node_modules/serverless-esbuild nodejs/node_modules
-cp -a node_modules/esbuild nodejs/node_modules
-cp -a node_modules/serverless-http nodejs/node_modules
+cp -a .ns-build/standalone/node_modules .ns-build/nodejs || exit 1
+cp -a node_modules/serverless .ns-build/nodejs/node_modules || exit 1
+cp -a node_modules/serverless-esbuild .ns-build/nodejs/node_modules || exit 1
+cp -a node_modules/esbuild .ns-build/nodejs/node_modules || exit 1
+cp -a node_modules/serverless-http .ns-build/nodejs/node_modules || exit 1
 
 # Zip node modules
 echo "Generating layer.zip ..."
-zip -r -q deployments/layer.zip nodejs
+( cd .ns-build/ && zip -r -q ../deployments/layer.zip nodejs ) || exit 1
 echo "layer.zip generated !"
 
 # Keep image optimization/redirection source code zips
-cd deployments
-mkdir ns-img-rdr
-mkdir image-optimization
-cd ..
-cp node_modules/ns-img-rdr/source.zip deployments/ns-img-rdr/
-cp node_modules/ns-img-opt/source.zip deployments/image-optimization/
+mkdir -p deployments/ns-img-rdr || exit 1
+mkdir -p deployments/image-optimization || exit 1
+cp node_modules/ns-img-rdr/source.zip deployments/ns-img-rdr/ || exit 1
+cp node_modules/ns-img-opt/source.zip deployments/image-optimization/ || exit 1
 
 # Keep necessary files
-cd standalone
-mkdir -p static/_next
-cp -a .next/static static/_next
+mkdir -p .ns-build/standalone/static/_next || exit 1
+cp -a .ns-build/standalone/.next/static .ns-build/standalone/static/_next || exit 1
 
 # Prepare source code
-rm -r node_modules
+test -d .ns-build/standalone/node_modules && rm -r .ns-build/standalone/node_modules
 
 # optinal: add node_modules
-if [[ $copyAllPackages == true ]]; then
-  cp -a ../.next/standalone/node_modules node_modules
+if [ $copyAllPackages == true ]; then
+  cp -a .next/standalone/node_modules .ns-build/standalone/node_modules || exit 1
 else
   mkdir node_modules
   for package in "${packages_to_copy[@]}"
   do
-    cp -a ../node_modules/$package node_modules/$package
+    cp -a node_modules/$package .ns-build/standalonenode_modules/$package || exit 1
   done
 fi
 
 # zip source code
 echo "Generating source.zip ..."
-zip -r -q ../deployments/source.zip * .[!.]*
+( cd .ns-build/standalone && zip -r -q ../../deployments/source.zip * .[!.]* ) || exit 1
 echo "source.zip generated !"
-cd ..
-
-# Clean-up
-rm -r .next
-# rm -r standalone
-rm -r nodejs
-
-# Remove installed node modules
-npm uninstall serverless serverless-esbuild esbuild serverless-http ns-img-opt ns-img-rdr


### PR DESCRIPTION
The bash script includes many parts that, if an error occurs, would cause the script to not fail correctly, or, even worse, leave the application in an unexpected state.

This improvement starts by introducing a cleanup function that runs on exit (`trap cleanup EXIT`), so that if the user interrupts the execution, the script correctly cleans up after itself.

Because the cleanup script has an expectation for the directory it runs in, it means the 'cd' commands could throw off its expected execution directory.  To this end, the 'cd' only runs in a sub-shell for the zip commands.

Next, most commands include an exit-on-failure ('|| exit 1').  This allows the script to better handle environment or build issues.

This also includes some extra cleanup.  The app-backup and nodejs and standalone directories are now put inside the new .ns-build directory.  This should help make .gitignore easier, and can help reduce root directory clutter and possible interference with the application structure.  Some bash-specific code changed to more sh-friendly syntax (such as `[[` to `[`), and included extra argument quoting.

The one line that seems odd is the `KEY="$(echo "$ARGUMENT" | cut -f1 -d=)"` - the '-f1' would take all fields before the '-d=' mark, but I'm not sure if that's the intended behavior; should this instead be a '-f2-'?

With a bit of extra effort, the argument parsing loop could be turned into a more general SH script instead of bash-specific, but I'll leave to that to another day.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to enhance file and directory exclusions, including new patterns for `.ns-build`, `.zip`, deployments, and standalone directories.
	- Improved the `ns-build.sh` script for better error handling and functionality, including a cleanup process and directory structure adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->