### PR TITLE
Return 404 for Non-Existent Prop

### DIFF
--- a/packages/ns-build/server.js
+++ b/packages/ns-build/server.js
@@ -48,18 +48,23 @@ const getProps = (event) => __awaiter(void 0, void 0, void 0, function* () {
     const path = './.next/server/pages/' +
         resolvedUrl.split('/').slice(1).join('/').replace('.json', '.js');
     showDebugLogs && console.log({ path });
-    /**
+    /*
      * Dynamically import the module from the specified path and
      * extracts the `getServerSideProps` function from that module to load
      * the server-side rendering logic dynamically based on the requested URL path.
      */
-    let getServerSidePropsVal;
-    try {
-        const { getServerSideProps } = require(path);
-        getServerSidePropsVal = getServerSideProps;
-    }
-    catch (err) {
-        showDebugLogs && console.log({ path, err });
+    const loadProps = (importPath) => {
+        try {
+            const { getServerSideProps } = require(importPath);
+            return getServerSideProps;
+        }
+        catch (err) {
+            showDebugLogs && console.log({ importPath, err });
+            return null;
+        }
+    };
+    const getServerSideProps = loadProps(path);
+    if (getServerSideProps === null) {
         return {
             statusCode: 404,
             body: 'resource not found',
@@ -71,7 +76,7 @@ const getProps = (event) => __awaiter(void 0, void 0, void 0, function* () {
         query: event.rawQueryString,
         resolvedUrl,
     };
-    const customResponse = yield getServerSidePropsVal(customSsrContext);
+    const customResponse = yield getServerSideProps(customSsrContext);
     showDebugLogs && console.log({ customResponse });
     const response = {};
     response.statusCode = 200;

--- a/packages/ns-build/server.js
+++ b/packages/ns-build/server.js
@@ -53,14 +53,25 @@ const getProps = (event) => __awaiter(void 0, void 0, void 0, function* () {
      * extracts the `getServerSideProps` function from that module to load
      * the server-side rendering logic dynamically based on the requested URL path.
      */
-    const { getServerSideProps } = require(path);
+    let getServerSidePropsVal;
+    try {
+        const { getServerSideProps } = require(path);
+        getServerSidePropsVal = getServerSideProps;
+    }
+    catch (err) {
+        showDebugLogs && console.log({ path, err });
+        return {
+            statusCode: 404,
+            body: 'resource not found',
+        };
+    }
     // Provide a custom server-side rendering context for the server-side rendering.
     const customSsrContext = {
         req: event,
         query: event.rawQueryString,
         resolvedUrl,
     };
-    const customResponse = yield getServerSideProps(customSsrContext);
+    const customResponse = yield getServerSidePropsVal(customSsrContext);
     showDebugLogs && console.log({ customResponse });
     const response = {};
     response.statusCode = 200;

--- a/packages/ns-build/server.ts
+++ b/packages/ns-build/server.ts
@@ -46,7 +46,17 @@ const getProps = async (event: any) => {
    * extracts the `getServerSideProps` function from that module to load
    * the server-side rendering logic dynamically based on the requested URL path.
    */
-  const { getServerSideProps } = require(path)
+  let getServerSidePropsVal
+  try {
+    const { getServerSideProps } = require(path)
+    getServerSidePropsVal = getServerSideProps
+  } catch (err) {
+    showDebugLogs && console.log({ path, err })
+    return {
+      statusCode: 404,
+      body: 'resource not found',
+    }
+  }
 
   // Provide a custom server-side rendering context for the server-side rendering.
   const customSsrContext = {
@@ -54,7 +64,7 @@ const getProps = async (event: any) => {
     query: event.rawQueryString,
     resolvedUrl,
   }
-  const customResponse = await getServerSideProps(customSsrContext)
+  const customResponse = await getServerSidePropsVal(customSsrContext)
   showDebugLogs && console.log({ customResponse })
 
   const response: any = {}


### PR DESCRIPTION
For the property construction, it's possible for either a bug or some other request to fetch a property file that does not exist.  The original code, if the page does not exist, would generate a 500 error and a stack trace.  This fix instead returns a 404 to indicate the requested resource does not exist.