### PR TITLE
add required providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 <!--  -->
 <!-- ## [Unreleased] -->
 
+## [v1.0.3] - 2024-06-28
+
+- Add required dependencies for the module
+
 ## [v1.0.2] - 2024-06-07
 
 - Mark `next` as peer dependency

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Please check our [testing guidelines](https://github.com/emyriounis/terraform-aw
 ```diff
 module "tf_next" {
 - source  = "emyriounis/nextjs-serverless/aws"
-- version = "1.0.2"
+- version = "1.0.3"
 + source = "../../../"
   ...
 }

--- a/examples/nextjs-v14/terraform/main.tf
+++ b/examples/nextjs-v14/terraform/main.tf
@@ -9,7 +9,7 @@ resource "aws_cloudfront_function" "test" {
 module "next_serverless" {
   # source = "../../../"
   source  = "emyriounis/nextjs-serverless/aws"
-  version = "1.0.2"
+  version = "1.0.3"
 
   providers = {
     aws.global_region = aws.global_region

--- a/modules/image-optimization/versions.tf
+++ b/modules/image-optimization/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.6.3"
+
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = [aws.global_region]
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.6.3"
+
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = [aws.global_region]
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes an issue that triggered the following warning:

`Warning: Reference to undefined provider`
`There is no explicit declaration for local provider name "aws.global_region" in module.next_serverless, so Terraform is assuming you mean to pass a configuration for "hashicorp/aws".`