### PR TITLE
add cloudfront cacehd paths input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 <!--  -->
 <!-- ## [Unreleased] -->
 
+## [v1.3.0] - 2025-02-11
+
+- Add `cloudfront_cached_paths` tf variable
+
 ## [v1.2.0] - 2024-12-23
 
 - Add `enable_image_optimization` tf variable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Please check our [testing guidelines](https://github.com/emyriounis/terraform-aw
 ```diff
 module "tf_next" {
 - source  = "emyriounis/nextjs-serverless/aws"
-- version = "1.2.0"
+- version = "1.3.0"
 + source = "../../../"
   ...
 }

--- a/examples/nextjs-v14/terraform/main.tf
+++ b/examples/nextjs-v14/terraform/main.tf
@@ -9,7 +9,7 @@ resource "aws_cloudfront_function" "test" {
 module "next_serverless" {
   # source = "../../../"
   source  = "emyriounis/nextjs-serverless/aws"
-  version = "1.2.0"
+  version = "1.3.0"
 
   providers = {
     aws.global_region = aws.global_region

--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,7 @@ module "distribution" {
   cloudfront_aliases             = var.cloudfront_aliases
   cloudfront_price_class         = var.cloudfront_price_class
 
+  cloudfront_cached_paths      = var.cloudfront_cached_paths
   cloudfront_cache_default_ttl = var.cloudfront_cache_default_ttl
   cloudfront_cache_max_ttl     = var.cloudfront_cache_max_ttl
   cloudfront_cache_min_ttl     = var.cloudfront_cache_min_ttl

--- a/modules/distribution/main.tf
+++ b/modules/distribution/main.tf
@@ -49,7 +49,8 @@ resource "aws_cloudfront_cache_policy" "next_distribution" {
 }
 
 resource "aws_cloudfront_cache_policy" "custom_paths_cache" {
-  name = "custom-paths-cache-policy"
+  count = length(var.cloudfront_cached_paths.paths) > 0 ? 1 : 0
+  name  = "${var.deployment_name}-custom-paths-cache-policy"
 
   default_ttl = var.cloudfront_cached_paths.default_ttl
   max_ttl     = var.cloudfront_cached_paths.max_ttl

--- a/modules/distribution/variables.tf
+++ b/modules/distribution/variables.tf
@@ -55,6 +55,15 @@ variable "public_assets_origin_id" {
   type = map(any)
 }
 
+variable "cloudfront_cached_paths" {
+  type = object({
+    paths       = list(string)
+    min_ttl     = number
+    default_ttl = number
+    max_ttl     = number
+  })
+}
+
 variable "cloudfront_cache_default_ttl" {
   type = number
 }

--- a/modules/distribution/variables.tf
+++ b/modules/distribution/variables.tf
@@ -56,12 +56,19 @@ variable "public_assets_origin_id" {
 }
 
 variable "cloudfront_cached_paths" {
+  description = "An object containing a list of paths to cache and min, default and max TTL values"
   type = object({
     paths       = list(string)
     min_ttl     = number
     default_ttl = number
     max_ttl     = number
   })
+  default = {
+    paths       = []
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+  }
 }
 
 variable "cloudfront_cache_default_ttl" {

--- a/modules/distribution/variables.tf
+++ b/modules/distribution/variables.tf
@@ -56,19 +56,12 @@ variable "public_assets_origin_id" {
 }
 
 variable "cloudfront_cached_paths" {
-  description = "An object containing a list of paths to cache and min, default and max TTL values"
   type = object({
     paths       = list(string)
     min_ttl     = number
     default_ttl = number
     max_ttl     = number
   })
-  default = {
-    paths       = []
-    min_ttl     = 0
-    default_ttl = 0
-    max_ttl     = 0
-  }
 }
 
 variable "cloudfront_cache_default_ttl" {

--- a/variables.tf
+++ b/variables.tf
@@ -117,6 +117,22 @@ variable "image_optimization_ephemeral_storage_size" {
   default     = 512
 }
 
+variable "cloudfront_cached_paths" {
+  description = "An object containing a list of paths to cache and min, default and max TTL values"
+  type = object({
+    paths       = list(string)
+    min_ttl     = number
+    default_ttl = number
+    max_ttl     = number
+  })
+  default = {
+    paths       = []
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+  }
+}
+
 variable "cloudfront_cache_default_ttl" {
   description = "Default TTL in seconds for ordered cache behaviors"
   type        = number


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced content distribution by introducing flexible, custom caching configurations for specific paths.
	- Added options to finely tune cache behavior, including adjustable time-to-live (TTL) settings, without impacting existing functionality.
	- Introduced a new variable for managing CloudFront cached paths, enhancing configuration options.

- **Chores**
	- Updated version number to `v1.3.0` in relevant documentation and module declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->