### PR TITLE
Add create_cloudfront_distribution tf variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 <!--  -->
 <!-- ## [Unreleased] -->
 
+## [v3.2.0] - 2026-04-21
+
+- Add `create_cloudfront_distribution` tf variable
+
 ## [v3.1.1] - 2026-04-08
 
 - Bugfix: bump various terraform module versions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Please check our [testing guidelines](https://github.com/emyriounis/terraform-aw
 ```diff
 module "tf_next" {
 - source  = "emyriounis/nextjs-serverless/aws"
-- version = "3.1.1"
+- version = "3.2.0"
 + source = "../../../"
   ...
 }

--- a/examples/nextjs-v15/terraform/main.tf
+++ b/examples/nextjs-v15/terraform/main.tf
@@ -9,7 +9,7 @@ resource "aws_cloudfront_function" "test" {
 module "next_serverless" {
   source = "../../../"
   # source  = "emyriounis/nextjs-serverless/aws"
-  # version = "3.1.1"
+  # version = "3.2.0"
 
   providers = {
     aws.global_region = aws.global_region

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,8 @@ module "image-optimization" {
 }
 
 module "distribution" {
+  count = var.create_cloudfront_distribution ? 1 : 0
+
   source = "./modules/distribution"
 
   static_assets_bucket    = module.static-assets-hosting.static_assets_bucket
@@ -99,15 +101,15 @@ resource "null_resource" "delete_resized_versions" {
 
 # resize new public assets
 data "http" "resize_image_version" {
-  for_each   = var.pre_resize_images ? module.public-assets-hosting.all_resized_images_paths : {}
+  for_each   = var.create_cloudfront_distribution && var.pre_resize_images ? module.public-assets-hosting.all_resized_images_paths : {}
   depends_on = [null_resource.create_cloudfront_invalidation]
 
-  url = "https://${module.distribution.next_distribution.domain_name}/_next/image/${each.value}"
+  url = "https://${module.distribution[0].next_distribution.domain_name}/_next/image/${each.value}"
 }
 
 # trigger create-invalidation after every deployment
 resource "null_resource" "create_cloudfront_invalidation" {
-  count      = var.create_cloudfront_invalidation ? 1 : 0
+  count      = var.create_cloudfront_distribution && var.create_cloudfront_invalidation ? 1 : 0
   depends_on = [null_resource.delete_resized_versions]
 
   triggers = {
@@ -115,6 +117,6 @@ resource "null_resource" "create_cloudfront_invalidation" {
   }
 
   provisioner "local-exec" {
-    command = "aws cloudfront create-invalidation --distribution-id ${module.distribution.next_distribution.id} --paths '/*' "
+    command = "aws cloudfront create-invalidation --distribution-id ${module.distribution[0].next_distribution.id} --paths '/*' "
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,11 +19,11 @@ output "server-side-rendering" {
 }
 
 output "distribution" {
-  value       = module.distribution
+  value       = var.create_cloudfront_distribution ? module.distribution[0] : {}
   description = "Resources created by the distribution module"
 }
 
 output "cloudfront_url" {
-  value       = module.distribution.next_distribution.domain_name
+  value       = var.create_cloudfront_distribution ? module.distribution[0].next_distribution.domain_name : null
   description = "The URL where cloudfront hosts the distribution"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,11 +19,11 @@ output "server-side-rendering" {
 }
 
 output "distribution" {
-  value       = var.create_cloudfront_distribution ? module.distribution[0] : {}
+  value       = one(module.distribution[*])
   description = "Resources created by the distribution module"
 }
 
 output "cloudfront_url" {
-  value       = var.create_cloudfront_distribution ? module.distribution[0].next_distribution.domain_name : null
+  value       = try(one(module.distribution[*]).next_distribution.domain_name, null)
   description = "The URL where cloudfront hosts the distribution"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -166,6 +166,13 @@ variable "cloudfront_function_associations" {
   default = []
 }
 
+variable "create_cloudfront_distribution" {
+  description = "Boolean to disable the cloudfront distribution creation"
+  type        = bool
+  default     = true
+
+}
+
 variable "create_cloudfront_invalidation" {
   description = "Boolean to disable the trigger for cloudfront invalidation after every deployment"
   type        = bool


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration option that enables users to optionally disable CloudFront distribution creation, providing greater flexibility and control over infrastructure deployment while reducing unnecessary resource allocation when content distribution is not required for their use case

* **Documentation**
  * Updated example configurations and contributing documentation to version 3.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->